### PR TITLE
Rest API + better ticket description

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ target/
 .project
 .settings
 
+#integration test configuration
+sonar.test.properties

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   </parent>
 
   <artifactId>sonar-jira-plugin</artifactId>
-  <version>1.3-SNAPSHOT</version>
+  <version>2.0-SNAPSHOT</version>
   <packaging>sonar-plugin</packaging>
 
   <name>JIRA Plugin for SonarQube</name>
@@ -81,6 +81,16 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+	    <groupId>com.atlassian.jira</groupId>
+	    <artifactId>jira-rest-java-client-api</artifactId>
+	    <version>2.0.0-m31</version>
+	</dependency>
+	<dependency>
+	    <groupId>com.atlassian.jira</groupId>
+	    <artifactId>jira-rest-java-client-core</artifactId>
+	    <version>2.0.0-m31</version>
+	</dependency>
+    <dependency>
       <groupId>axis</groupId>
       <artifactId>axis</artifactId>
       <version>1.3</version>
@@ -151,5 +161,35 @@
       </plugin>
     </plugins>
   </build>
+
+	<repositories>
+         <repository>
+           <id>atlassian-public</id>
+           <url>https://m2proxy.atlassian.com/repository/public</url>
+           <snapshots>
+             <enabled>true</enabled>
+             <updatePolicy>daily</updatePolicy>
+             <checksumPolicy>warn</checksumPolicy>
+           </snapshots>
+           <releases>
+             <enabled>true</enabled>
+             <checksumPolicy>warn</checksumPolicy>
+           </releases>
+         </repository>
+       </repositories>
+
+       <pluginRepositories>
+         <pluginRepository>
+           <id>atlassian-public</id>
+           <url>https://m2proxy.atlassian.com/repository/public</url>
+           <releases>
+             <enabled>true</enabled>
+             <checksumPolicy>warn</checksumPolicy>
+           </releases>
+           <snapshots>
+             <checksumPolicy>warn</checksumPolicy>
+           </snapshots>
+         </pluginRepository>
+       </pluginRepositories>
 
 </project>

--- a/src/main/java/org/sonar/plugins/jira/BasicJiraService.java
+++ b/src/main/java/org/sonar/plugins/jira/BasicJiraService.java
@@ -1,0 +1,104 @@
+package org.sonar.plugins.jira;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.sonar.api.CoreProperties;
+import org.sonar.api.config.Settings;
+import org.sonar.api.issue.Issue;
+import org.sonar.api.rules.Rule;
+import org.sonar.api.rules.RuleFinder;
+import org.sonar.api.rules.RulePriority;
+import org.sonar.api.utils.SonarException;
+
+public abstract class BasicJiraService implements JiraService {
+
+	private final Settings settings;
+	private final RuleFinder ruleFinder;
+
+	private static final String QUOTE = "\n{quote}\n";
+	
+	public BasicJiraService(Settings sonarSettings, RuleFinder ruleFinder) {
+		super();
+		this.settings = sonarSettings;
+		this.ruleFinder = ruleFinder;
+	}
+	
+	protected String getType() {
+		return settings.getString(JiraConstants.JIRA_ISSUE_TYPE_ID);
+	}
+	
+	protected String getProject() {
+		return settings.getString(JiraConstants.JIRA_PROJECT_KEY_PROPERTY);
+	}
+	
+	protected String sonarSeverityToJiraPriorityId(RulePriority reviewSeverity) {
+		    final String priorityId;
+		    switch (reviewSeverity) {
+		      case INFO:
+		        priorityId = settings.getString(JiraConstants.JIRA_INFO_PRIORITY_ID);
+		        break;
+		      case MINOR:
+		        priorityId = settings.getString(JiraConstants.JIRA_MINOR_PRIORITY_ID);
+		        break;
+		      case MAJOR:
+		        priorityId = settings.getString(JiraConstants.JIRA_MAJOR_PRIORITY_ID);
+		        break;
+		      case CRITICAL:
+		        priorityId = settings.getString(JiraConstants.JIRA_CRITICAL_PRIORITY_ID);
+		        break;
+		      case BLOCKER:
+		        priorityId = settings.getString(JiraConstants.JIRA_BLOCKER_PRIORITY_ID);
+		        break;
+		      default:
+		        throw new SonarException("Unable to convert review severity to JIRA priority: " + reviewSeverity);
+		    }
+		    return priorityId;
+	}
+	
+	protected String generateIssueSummary(Issue sonarIssue) {
+		  Rule rule = ruleFinder.findByKey(sonarIssue.ruleKey());
+
+		  StringBuilder summary = new StringBuilder("SonarQube Issue #");
+		  summary.append(sonarIssue.key());
+		  if (rule != null && rule.getName() != null) {
+		      summary.append(" - ");
+		      summary.append(rule.getName().toString());
+		    }
+		    return summary.toString();
+	}
+	
+    protected String generateIssueDescription(Issue sonarIssue) {
+		    StringBuilder description = new StringBuilder("Issue detail:");
+		    description.append(QUOTE);
+		    description.append(sonarIssue.message());
+		    description.append(QUOTE);
+		    if(sonarIssue.componentKey() != null)
+		    	description.append("\ncomponent "+sonarIssue.componentKey());
+			if(sonarIssue.line() != null && sonarIssue.line() > 0)
+				description.append(", line "+sonarIssue.line());		
+		    description.append("\n\nCheck it on SonarQube: ");
+		    description.append(settings.getString(CoreProperties.SERVER_BASE_URL));
+		    description.append("/issues/show/");
+		    description.append(sonarIssue.key());
+		    return description.toString();
+	}
+	
+    protected String getComponentId()
+    {
+    	if (settings.hasKey(JiraConstants.JIRA_ISSUE_COMPONENT_ID)) {
+  	      	return settings.getString(JiraConstants.JIRA_ISSUE_COMPONENT_ID);  	      
+    	} else {
+    		return null;
+    	}
+    }
+    
+    protected List<String> getLabels() {
+		List<String> labels = new ArrayList<>();
+		String sonarLabel = settings.getString(JiraConstants.JIRA_ISSUE_SONAR_LABEL);
+		if(sonarLabel != null)
+			labels.add(sonarLabel);
+		return labels;
+	}
+    
+}

--- a/src/main/java/org/sonar/plugins/jira/BasicJiraService.java
+++ b/src/main/java/org/sonar/plugins/jira/BasicJiraService.java
@@ -1,3 +1,23 @@
+/*
+ * Sonar, open source software quality management tool.
+ * Copyright (C) 2009 SonarSource
+ * mailto:contact AT sonarsource DOT com
+ *
+ * Sonar is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * Sonar is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with Sonar; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+
 package org.sonar.plugins.jira;
 
 import java.util.ArrayList;

--- a/src/main/java/org/sonar/plugins/jira/JiraConstants.java
+++ b/src/main/java/org/sonar/plugins/jira/JiraConstants.java
@@ -26,9 +26,13 @@ public final class JiraConstants {
   // ===================== PLUGIN PROPERTIES =====================
 
   public static final String SERVER_URL_PROPERTY = "sonar.jira.url";
-
-  public static final String SOAP_BASE_URL_PROPERTY = "sonar.jira.soap.url";
+  public static final String JIRA_USE_REST_PROPERTY = "sonar.jira.rest";
+  
+  public static final String SOAP_BASE_URL_PROPERTY = "sonar.jira.soap.url";  
   public static final String SOAP_BASE_URL_DEF_VALUE = "/rpc/soap/jirasoapservice-v2";
+  
+  public static final String REST_BASE_URL_PROPERTY = "sonar.jira.rest.url";
+  public static final String REST_BASE_URL_DEF_VALUE = "/";
 
   public static final String USERNAME_PROPERTY = "sonar.jira.login.secured";
 
@@ -47,6 +51,7 @@ public final class JiraConstants {
   public static final String JIRA_ISSUE_TYPE_ID = "sonar.jira.issue.type.id";
 
   public static final String JIRA_ISSUE_COMPONENT_ID = "sonar.jira.issue.component.id";
+  public static final String JIRA_ISSUE_SONAR_LABEL = "sonar.jira.issue.sonar.label";
 
   private JiraConstants() {
   }

--- a/src/main/java/org/sonar/plugins/jira/JiraService.java
+++ b/src/main/java/org/sonar/plugins/jira/JiraService.java
@@ -1,3 +1,23 @@
+/*
+ * Sonar, open source software quality management tool.
+ * Copyright (C) 2009 SonarSource
+ * mailto:contact AT sonarsource DOT com
+ *
+ * Sonar is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * Sonar is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with Sonar; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+
 package org.sonar.plugins.jira;
 
 import org.sonar.api.issue.Issue;

--- a/src/main/java/org/sonar/plugins/jira/JiraService.java
+++ b/src/main/java/org/sonar/plugins/jira/JiraService.java
@@ -1,0 +1,11 @@
+package org.sonar.plugins.jira;
+
+import org.sonar.api.issue.Issue;
+
+import com.atlassian.jira.rest.client.api.domain.BasicIssue;
+
+public interface JiraService {
+
+	BasicIssue createIssue(String authToken, Issue sonarIssue);
+
+}

--- a/src/main/java/org/sonar/plugins/jira/JiraSession.java
+++ b/src/main/java/org/sonar/plugins/jira/JiraSession.java
@@ -1,0 +1,17 @@
+package org.sonar.plugins.jira;
+
+import java.net.URL;
+
+import org.sonar.api.config.Settings;
+import org.sonar.api.rules.RuleFinder;
+
+public interface JiraSession extends AutoCloseable
+{
+
+	public void connect(String userName, String password);
+	public JiraService getJiraService(RuleFinder ruleFinder, Settings settings);
+	public String getAuthenticationToken();
+	public URL getWebServiceUrl();
+	public void close();
+	
+}

--- a/src/main/java/org/sonar/plugins/jira/JiraSession.java
+++ b/src/main/java/org/sonar/plugins/jira/JiraSession.java
@@ -1,3 +1,23 @@
+/*
+ * Sonar, open source software quality management tool.
+ * Copyright (C) 2009 SonarSource
+ * mailto:contact AT sonarsource DOT com
+ *
+ * Sonar is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * Sonar is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with Sonar; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+
 package org.sonar.plugins.jira;
 
 import java.net.URL;

--- a/src/main/java/org/sonar/plugins/jira/metrics/JiraSensor.java
+++ b/src/main/java/org/sonar/plugins/jira/metrics/JiraSensor.java
@@ -86,18 +86,16 @@ public class JiraSensor implements Sensor {
     }
     return project.isRoot() && !missingMandatoryParameters();
   }
-
+  
   public void analyse(Project project, SensorContext context) {
-    try {
-      JiraSoapSession session = new JiraSoapSession(new URL(getServerUrl() + "/rpc/soap/jirasoapservice-v2"));
+    try (JiraSoapSession session = new JiraSoapSession(new URL(getServerUrl() + "/rpc/soap/jirasoapservice-v2"));) {
+      
       session.connect(getUsername(), getPassword());
-
+      
       JiraSoapService service = session.getJiraSoapService();
       String authToken = session.getAuthenticationToken();
-
+      
       runAnalysis(context, service, authToken);
-
-      session.disconnect();
     } catch (RemoteException e) {
       LOG.error("Error accessing Jira web service, please verify the parameters", e);
     } catch (MalformedURLException e) {

--- a/src/main/java/org/sonar/plugins/jira/rest/JiraRestServiceWrapper.java
+++ b/src/main/java/org/sonar/plugins/jira/rest/JiraRestServiceWrapper.java
@@ -1,9 +1,28 @@
+/*
+ * Sonar, open source software quality management tool.
+ * Copyright (C) 2009 SonarSource
+ * mailto:contact AT sonarsource DOT com
+ *
+ * Sonar is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * Sonar is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with Sonar; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+
 package org.sonar.plugins.jira.rest;
 
 import java.util.Collection;
 import java.util.List;
 import java.util.Map.Entry;
-import java.util.concurrent.ExecutionException;
 
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;

--- a/src/main/java/org/sonar/plugins/jira/rest/JiraRestServiceWrapper.java
+++ b/src/main/java/org/sonar/plugins/jira/rest/JiraRestServiceWrapper.java
@@ -1,0 +1,109 @@
+package org.sonar.plugins.jira.rest;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.concurrent.ExecutionException;
+
+import org.codehaus.jettison.json.JSONException;
+import org.codehaus.jettison.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.sonar.api.config.Settings;
+import org.sonar.api.issue.Issue;
+import org.sonar.api.rules.RuleFinder;
+import org.sonar.api.rules.RulePriority;
+import org.sonar.plugins.jira.BasicJiraService;
+
+import com.atlassian.jira.rest.client.api.JiraRestClient;
+import com.atlassian.jira.rest.client.api.RestClientException;
+import com.atlassian.jira.rest.client.api.domain.BasicIssue;
+import com.atlassian.jira.rest.client.api.domain.IssueFieldId;
+import com.atlassian.jira.rest.client.api.domain.input.ComplexIssueInputFieldValue;
+import com.atlassian.jira.rest.client.api.domain.input.IssueInput;
+import com.atlassian.jira.rest.client.api.domain.input.IssueInputBuilder;
+import com.atlassian.jira.rest.client.api.domain.util.ErrorCollection;
+import com.atlassian.jira.rest.client.internal.json.gen.IssueInputJsonGenerator;
+import com.atlassian.jira.rpc.soap.client.RemoteComponent;
+import com.atlassian.util.concurrent.Promise;
+import com.google.common.collect.Lists;
+
+public class JiraRestServiceWrapper extends BasicJiraService {
+
+	private static final Logger LOG = LoggerFactory.getLogger(JiraRestServiceWrapper.class);
+	
+	private JiraRestClient jiraRestClient;
+	
+	public JiraRestServiceWrapper(JiraRestClient jiraRestClient, RuleFinder ruleFinder, Settings settings) {
+		super(settings, ruleFinder);
+		this.jiraRestClient = jiraRestClient;
+	}
+	
+	@Override
+	public BasicIssue createIssue(String authToken, Issue sonarIssue) {
+		return createIssue(jiraRestClient.getIssueClient().createIssue(convertIssue(sonarIssue)));
+	}
+	
+	private IssueInput convertIssue(Issue sonarIssue) {
+		IssueInputBuilder builder = new IssueInputBuilder(getProject(), Long.valueOf(getType()), generateIssueSummary(sonarIssue));
+		builder.setPriorityId(Long.valueOf(sonarSeverityToJiraPriorityId(RulePriority.valueOf(sonarIssue.severity()))));
+		builder.setDescription(generateIssueDescription(sonarIssue));		
+		
+		String componentId = getComponentId();
+	    if(componentId != null)
+	    {	    	
+	    	RemoteComponent rc = new RemoteComponent();
+	    	rc.setId(componentId);
+	    	builder.setFieldValue(IssueFieldId.COMPONENTS_FIELD.id, Lists.newArrayList(ComplexIssueInputFieldValue.with("id", componentId)));
+	    }
+	    
+	    List<String> labels = getLabels();
+	    if(labels != null && !labels.isEmpty())
+	    	builder.setFieldValue(IssueFieldId.LABELS_FIELD.id, labels);
+	    IssueInput in = builder.build();
+	    
+	    
+	    
+	    if(LOG.isDebugEnabled())
+	    	generateJson(in);
+	    return in;
+	}
+	
+	private void generateJson( IssueInput in)
+	{
+		 try {
+			IssueInputJsonGenerator generator = new IssueInputJsonGenerator();
+			JSONObject generate = generator.generate(in);
+	     	LOG.debug(generate.toString());
+		 } catch(JSONException e) {
+			 e.printStackTrace();
+		 }
+	}
+	
+	private BasicIssue createIssue(Promise<BasicIssue> createIssue) {
+		try {
+			BasicIssue basicIssue = createIssue.claim();			
+			return basicIssue;
+		} catch (RestClientException e) {
+			Collection<ErrorCollection> errorCollections = e.getErrorCollections();
+			throw new IllegalStateException(collectJiraErrorMessages(errorCollections), e);
+		}
+		
+	}
+	
+	private String collectJiraErrorMessages(Collection<ErrorCollection> errorCollections) {
+		StringBuilder stringBuilder = new StringBuilder();
+		for(ErrorCollection errorCollection : errorCollections)
+		{
+			for (String string : errorCollection.getErrorMessages()) {
+				stringBuilder.append(string).append('\n');
+			}
+			for (Entry<String, String> entry : errorCollection.getErrors().entrySet()) {
+				//project is required may be project key is invalid ;)
+				stringBuilder.append(entry.getValue()).append('\n');
+			}
+		}
+		return stringBuilder.toString();
+	}
+	
+}

--- a/src/main/java/org/sonar/plugins/jira/rest/JiraRestSession.java
+++ b/src/main/java/org/sonar/plugins/jira/rest/JiraRestSession.java
@@ -23,7 +23,6 @@ package org.sonar.plugins.jira.rest;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.rmi.RemoteException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/org/sonar/plugins/jira/rest/JiraRestSession.java
+++ b/src/main/java/org/sonar/plugins/jira/rest/JiraRestSession.java
@@ -1,0 +1,93 @@
+/*
+ * Sonar, open source software quality management tool.
+ * Copyright (C) 2009 SonarSource
+ * mailto:contact AT sonarsource DOT com
+ *
+ * Sonar is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * Sonar is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with Sonar; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+
+package org.sonar.plugins.jira.rest;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.rmi.RemoteException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.sonar.api.config.Settings;
+import org.sonar.api.rules.RuleFinder;
+import org.sonar.plugins.jira.JiraService;
+import org.sonar.plugins.jira.JiraSession;
+
+import com.atlassian.jira.rest.client.api.JiraRestClient;
+import com.atlassian.jira.rest.client.api.JiraRestClientFactory;
+import com.atlassian.jira.rest.client.internal.async.AsynchronousJiraRestClientFactory;
+
+/**
+ * This represents a REST session with JIRA
+ */
+public class JiraRestSession implements JiraSession {
+	
+	private static final Logger LOG = LoggerFactory.getLogger(JiraRestSession.class);
+
+	private JiraRestClientFactory jcf;
+	private JiraRestClient jiraRestClient;
+	private URL webServiceUrl;
+	
+	public JiraRestSession(URL url) {
+		this.webServiceUrl = url;
+		jcf = new AsynchronousJiraRestClientFactory();
+	}
+
+	public void connect(String userName, String password) {
+		LOG.debug("Connnecting via SOAP as : {}", userName);
+		try {
+			jiraRestClient = jcf.createWithBasicHttpAuthentication(webServiceUrl.toURI(), userName, password);
+			LOG.debug("SOAP Session service endpoint at " + webServiceUrl.toString());
+		} catch (URISyntaxException e) {
+			throw new IllegalStateException("ServiceException during JiraSoapService contruction", e);
+		}
+		LOG.debug("Connected");
+	}
+	
+	@Override
+	public void close() {
+		try {
+			this.jiraRestClient.close();
+		} catch (IOException e) {
+			throw new IllegalStateException("ServiceException during JiraSoapService destruction", e);
+		}
+	}
+	
+	public JiraRestClient getJiraRestClient() {
+		return jiraRestClient;
+	}
+
+	public URL getWebServiceUrl() {
+		return webServiceUrl;
+	}
+
+	@Override
+	public JiraService getJiraService(RuleFinder ruleFinder, Settings settings) {
+		return new JiraRestServiceWrapper(this.getJiraRestClient(), ruleFinder, settings);
+	}
+
+	@Override
+	public String getAuthenticationToken() {
+		return null;
+	}
+
+}

--- a/src/main/java/org/sonar/plugins/jira/reviews/JiraIssueCreator.java
+++ b/src/main/java/org/sonar/plugins/jira/reviews/JiraIssueCreator.java
@@ -19,40 +19,51 @@
  */
 package org.sonar.plugins.jira.reviews;
 
-import com.atlassian.jira.rpc.soap.client.JiraSoapService;
-import com.atlassian.jira.rpc.soap.client.RemoteAuthenticationException;
-import com.atlassian.jira.rpc.soap.client.RemoteComponent;
-import com.atlassian.jira.rpc.soap.client.RemoteIssue;
-import com.atlassian.jira.rpc.soap.client.RemotePermissionException;
-import com.atlassian.jira.rpc.soap.client.RemoteValidationException;
-import org.apache.commons.lang.StringUtils;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.rmi.RemoteException;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.sonar.api.CoreProperties;
 import org.sonar.api.Properties;
 import org.sonar.api.Property;
 import org.sonar.api.PropertyType;
 import org.sonar.api.ServerExtension;
 import org.sonar.api.config.Settings;
 import org.sonar.api.issue.Issue;
-import org.sonar.api.rules.Rule;
 import org.sonar.api.rules.RuleFinder;
-import org.sonar.api.rules.RulePriority;
-import org.sonar.api.utils.SonarException;
 import org.sonar.plugins.jira.JiraConstants;
+import org.sonar.plugins.jira.JiraService;
+import org.sonar.plugins.jira.JiraSession;
+import org.sonar.plugins.jira.rest.JiraRestSession;
 import org.sonar.plugins.jira.soap.JiraSoapSession;
 
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.rmi.RemoteException;
+import com.atlassian.jira.rest.client.api.domain.BasicIssue;
 
 /**
  * SOAP client class that is used for creating issues on a JIRA server
  */
-@Properties({
+@Properties({	
+  @Property(
+    key = JiraConstants.JIRA_USE_REST_PROPERTY,
+    defaultValue = "false",
+    name = "Use rest api",
+    description = "Use rest api instead of soap",
+    global = true,
+    project = false
+  ),
   @Property(
     key = JiraConstants.SOAP_BASE_URL_PROPERTY,
     defaultValue = JiraConstants.SOAP_BASE_URL_DEF_VALUE,
+    name = "SOAP base URL",
+    description = "Base URL for the SOAP API of the JIRA server",
+    global = true,
+    project = true
+  ),
+  @Property(
+    key = JiraConstants.REST_BASE_URL_PROPERTY,
+    defaultValue = JiraConstants.REST_BASE_URL_DEF_VALUE,
     name = "SOAP base URL",
     description = "Base URL for the SOAP API of the JIRA server",
     global = true,
@@ -128,147 +139,87 @@ import java.rmi.RemoteException;
     global = false,
     project = true,
     type = PropertyType.INTEGER
+  ),
+  @Property(
+    key = JiraConstants.JIRA_ISSUE_SONAR_LABEL,
+    defaultValue = "SONAR",
+    name = "Jira label",
+    description = "JIRA label for all sonar issues.",
+    global = true,
+    project = true,
+    type = PropertyType.STRING
   )
 })
 public class JiraIssueCreator implements ServerExtension {
-
-  private static final String QUOTE = "\n{quote}\n";
+	
   private static final Logger LOG = LoggerFactory.getLogger(JiraIssueCreator.class);
   private final RuleFinder ruleFinder;
-
+  
   public JiraIssueCreator(RuleFinder ruleFinder) {
     this.ruleFinder = ruleFinder;
   }
-
-  public RemoteIssue createIssue(Issue sonarIssue, Settings settings) throws RemoteException {
-    JiraSoapSession soapSession = createSoapSession(settings);
-
-    return doCreateIssue(sonarIssue, soapSession, settings);
+  
+  public BasicIssue createIssue(Issue sonarIssue, Settings settings) throws RemoteException {    
+    try (JiraSession soapSession = createJiraSession(settings);) 
+    {
+    	return doCreateIssue(sonarIssue, soapSession, settings);
+    }
+  }
+  
+  protected JiraSession createJiraSession(Settings settings) {        
+	Boolean useRest = settings.getBoolean(JiraConstants.JIRA_USE_REST_PROPERTY);
+	  
+	if(useRest)
+    {
+    	return createRestSession(settings);
+    } else {
+    	return createSoapSession(settings);
+    }
+  }
+  
+  private JiraSession createRestSession(Settings settings) {
+	String jiraUrl = settings.getString(JiraConstants.SERVER_URL_PROPERTY);
+	String baseUrl = settings.getString(JiraConstants.REST_BASE_URL_PROPERTY);
+	
+	String completeUrl = jiraUrl + baseUrl;
+	try {
+	  return new JiraRestSession(new URL(completeUrl));
+  	} catch (MalformedURLException e) {
+      LOG.error("The JIRA server URL is not a valid one: " + completeUrl, e);
+      throw new IllegalStateException("The JIRA server URL is not a valid one: " + completeUrl, e);
+    }
   }
 
-  protected JiraSoapSession createSoapSession(Settings settings) {
-    String jiraUrl = settings.getString(JiraConstants.SERVER_URL_PROPERTY);
+  protected JiraSession createSoapSession(Settings settings) {
+	String jiraUrl = settings.getString(JiraConstants.SERVER_URL_PROPERTY);
     String baseUrl = settings.getString(JiraConstants.SOAP_BASE_URL_PROPERTY);
+    
     String completeUrl = jiraUrl + baseUrl;
-
-    // get handle to the JIRA SOAP Service from a client point of view
-    JiraSoapSession soapSession = null;
+	// get handle to the JIRA SOAP Service from a client point of view
     try {
-      soapSession = new JiraSoapSession(new URL(completeUrl));
+      return new JiraSoapSession(new URL(completeUrl));      
     } catch (MalformedURLException e) {
       LOG.error("The JIRA server URL is not a valid one: " + completeUrl, e);
       throw new IllegalStateException("The JIRA server URL is not a valid one: " + completeUrl, e);
     }
-    return soapSession;
   }
-
-  protected RemoteIssue doCreateIssue(Issue sonarIssue, JiraSoapSession soapSession, Settings settings) {
+  
+  protected BasicIssue doCreateIssue(Issue sonarIssue, JiraSession soapSession, Settings settings) 
+  {
     // Connect to JIRA
-    String jiraUrl = settings.getString(JiraConstants.SERVER_URL_PROPERTY);
     String userName = settings.getString(JiraConstants.USERNAME_PROPERTY);
     String password = settings.getString(JiraConstants.PASSWORD_PROPERTY);
-    try {
-      soapSession.connect(userName, password);
-    } catch (RemoteException e) {
-      throw new IllegalStateException("Impossible to connect to the JIRA server (" + jiraUrl + ").", e);
-    }
-
+    soapSession.connect(userName, password);
     // The JIRA SOAP Service and authentication token are used to make authentication calls
-    JiraSoapService jiraSoapService = soapSession.getJiraSoapService();
+    JiraService jiraSoapService = soapSession.getJiraService(ruleFinder, settings);
     String authToken = soapSession.getAuthenticationToken();
-
+    
     // And create the issue
-    RemoteIssue issue = initRemoteIssue(sonarIssue, settings);
-    RemoteIssue returnedIssue = sendRequest(jiraSoapService, authToken, issue, jiraUrl, userName);
-
+    BasicIssue returnedIssue = jiraSoapService.createIssue(authToken, sonarIssue);
     String issueKey = returnedIssue.getKey();
     LOG.debug("Successfully created issue {}", issueKey);
 
     return returnedIssue;
   }
-
-  protected RemoteIssue sendRequest(JiraSoapService jiraSoapService, String authToken, RemoteIssue issue, String jiraUrl, String userName) {
-    try {
-      return jiraSoapService.createIssue(authToken, issue);
-    } catch (RemoteAuthenticationException e) {
-      throw new IllegalStateException("Impossible to connect to the JIRA server (" + jiraUrl + ") because of invalid credentials for user " + userName, e);
-    } catch (RemotePermissionException e) {
-      throw new IllegalStateException("Impossible to create the issue on the JIRA server (" + jiraUrl + ") because user " + userName + " does not have enough rights.", e);
-    } catch (RemoteValidationException e) {
-      // Unfortunately the detailed cause of the error is not in fault details (ie stack) but only in fault string
-      String message = StringUtils.removeStart(e.getFaultString(), "com.atlassian.jira.rpc.exception.RemoteValidationException:").trim();
-      throw new IllegalStateException("Impossible to create the issue on the JIRA server (" + jiraUrl + "): " + message, e);
-    } catch (RemoteException e) {
-      throw new IllegalStateException("Impossible to create the issue on the JIRA server (" + jiraUrl + ")", e);
-    }
-  }
-
-  protected RemoteIssue initRemoteIssue(Issue sonarIssue, Settings settings) {
-    RemoteIssue issue = new RemoteIssue();
-    issue.setProject(settings.getString(JiraConstants.JIRA_PROJECT_KEY_PROPERTY));
-    issue.setType(settings.getString(JiraConstants.JIRA_ISSUE_TYPE_ID));
-    issue.setPriority(sonarSeverityToJiraPriorityId(RulePriority.valueOf(sonarIssue.severity()), settings));
-    issue.setSummary(generateIssueSummary(sonarIssue));
-    issue.setDescription(generateIssueDescription(sonarIssue, settings));
-    if (settings.hasKey(JiraConstants.JIRA_ISSUE_COMPONENT_ID)) {
-      String componentId = settings.getString(JiraConstants.JIRA_ISSUE_COMPONENT_ID);
-      RemoteComponent rc = new RemoteComponent();
-      rc.setId(componentId);
-      issue.setComponents(new RemoteComponent[] {rc});
-    }
-    return issue;
-  }
-
-  protected String generateIssueSummary(Issue sonarIssue) {
-    Rule rule = ruleFinder.findByKey(sonarIssue.ruleKey());
-
-    StringBuilder summary = new StringBuilder("SonarQube Issue #");
-    summary.append(sonarIssue.key());
-    if (rule != null && rule.getName() != null) {
-      summary.append(" - ");
-      summary.append(rule.getName().toString());
-    }
-    return summary.toString();
-  }
-
-  protected String generateIssueDescription(Issue sonarIssue, Settings settings) {
-    StringBuilder description = new StringBuilder("Issue detail:");
-    description.append(QUOTE);
-    description.append(sonarIssue.message());
-    description.append(QUOTE);
-    if(sonarIssue.componentKey() != null)
-    	description.append("\ncomponent "+sonarIssue.componentKey());
-	if(sonarIssue.line() != null && sonarIssue.line() > 0)
-		description.append(", line "+sonarIssue.line());		
-    description.append("\n\nCheck it on SonarQube: ");
-    description.append(settings.getString(CoreProperties.SERVER_BASE_URL));
-    description.append("/issues/show/");
-    description.append(sonarIssue.key());
-    return description.toString();
-  }
-
-  protected String sonarSeverityToJiraPriorityId(RulePriority reviewSeverity, Settings settings) {
-    final String priorityId;
-    switch (reviewSeverity) {
-      case INFO:
-        priorityId = settings.getString(JiraConstants.JIRA_INFO_PRIORITY_ID);
-        break;
-      case MINOR:
-        priorityId = settings.getString(JiraConstants.JIRA_MINOR_PRIORITY_ID);
-        break;
-      case MAJOR:
-        priorityId = settings.getString(JiraConstants.JIRA_MAJOR_PRIORITY_ID);
-        break;
-      case CRITICAL:
-        priorityId = settings.getString(JiraConstants.JIRA_CRITICAL_PRIORITY_ID);
-        break;
-      case BLOCKER:
-        priorityId = settings.getString(JiraConstants.JIRA_BLOCKER_PRIORITY_ID);
-        break;
-      default:
-        throw new SonarException("Unable to convert review severity to JIRA priority: " + reviewSeverity);
-    }
-    return priorityId;
-  }
-
+  
 }

--- a/src/main/java/org/sonar/plugins/jira/reviews/JiraIssueCreator.java
+++ b/src/main/java/org/sonar/plugins/jira/reviews/JiraIssueCreator.java
@@ -236,6 +236,9 @@ public class JiraIssueCreator implements ServerExtension {
     description.append(QUOTE);
     description.append(sonarIssue.message());
     description.append(QUOTE);
+	description.append("\ncomponent "+sonarIssue.componentKey());
+	if(sonarIssue.line() > 0)
+		description.append(", line "+sonarIssue.line());		
     description.append("\n\nCheck it on SonarQube: ");
     description.append(settings.getString(CoreProperties.SERVER_BASE_URL));
     description.append("/issues/show/");

--- a/src/main/java/org/sonar/plugins/jira/reviews/JiraIssueCreator.java
+++ b/src/main/java/org/sonar/plugins/jira/reviews/JiraIssueCreator.java
@@ -236,8 +236,9 @@ public class JiraIssueCreator implements ServerExtension {
     description.append(QUOTE);
     description.append(sonarIssue.message());
     description.append(QUOTE);
-	description.append("\ncomponent "+sonarIssue.componentKey());
-	if(sonarIssue.line() > 0)
+    if(sonarIssue.componentKey() != null)
+    	description.append("\ncomponent "+sonarIssue.componentKey());
+	if(sonarIssue.line() != null && sonarIssue.line() > 0)
 		description.append(", line "+sonarIssue.line());		
     description.append("\n\nCheck it on SonarQube: ");
     description.append(settings.getString(CoreProperties.SERVER_BASE_URL));

--- a/src/main/java/org/sonar/plugins/jira/reviews/JiraIssueCreator.java
+++ b/src/main/java/org/sonar/plugins/jira/reviews/JiraIssueCreator.java
@@ -19,7 +19,6 @@
  */
 package org.sonar.plugins.jira.reviews;
 
-import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.rmi.RemoteException;
@@ -64,8 +63,8 @@ import com.atlassian.jira.rest.client.api.domain.BasicIssue;
   @Property(
     key = JiraConstants.REST_BASE_URL_PROPERTY,
     defaultValue = JiraConstants.REST_BASE_URL_DEF_VALUE,
-    name = "SOAP base URL",
-    description = "Base URL for the SOAP API of the JIRA server",
+    name = "REST base URL",
+    description = "Base URL for the REST API of the JIRA server",
     global = true,
     project = true
   ),

--- a/src/main/java/org/sonar/plugins/jira/reviews/JiraIssueCreator.java
+++ b/src/main/java/org/sonar/plugins/jira/reviews/JiraIssueCreator.java
@@ -238,7 +238,7 @@ public class JiraIssueCreator implements ServerExtension {
     description.append(QUOTE);
     description.append("\n\nCheck it on SonarQube: ");
     description.append(settings.getString(CoreProperties.SERVER_BASE_URL));
-    description.append("/issue/show/");
+    description.append("/issues/show/");
     description.append(sonarIssue.key());
     return description.toString();
   }

--- a/src/main/java/org/sonar/plugins/jira/reviews/LinkFunction.java
+++ b/src/main/java/org/sonar/plugins/jira/reviews/LinkFunction.java
@@ -19,14 +19,15 @@
  */
 package org.sonar.plugins.jira.reviews;
 
-import com.atlassian.jira.rpc.soap.client.RemoteIssue;
-import com.google.common.annotations.VisibleForTesting;
+import java.rmi.RemoteException;
+
 import org.sonar.api.ServerExtension;
 import org.sonar.api.config.Settings;
 import org.sonar.api.issue.action.Function;
 import org.sonar.plugins.jira.JiraConstants;
 
-import java.rmi.RemoteException;
+import com.atlassian.jira.rest.client.api.domain.BasicIssue;
+import com.google.common.annotations.VisibleForTesting;
 
 public class LinkFunction implements Function, ServerExtension {
 
@@ -42,7 +43,7 @@ public class LinkFunction implements Function, ServerExtension {
   }
 
   protected void createJiraIssue(Context context) {
-    RemoteIssue issue;
+	BasicIssue issue;
     try {
       issue = jiraIssueCreator.createIssue(context.issue(), context.projectSettings());
     } catch (RemoteException e) {
@@ -76,11 +77,11 @@ public class LinkFunction implements Function, ServerExtension {
     }
   }
 
-  protected void createComment(RemoteIssue issue, Context context) {
+  protected void createComment(BasicIssue issue, Context context) {
     context.addComment(generateCommentText(issue, context));
   }
-
-  protected String generateCommentText(RemoteIssue issue, Context context) {
+  
+  protected String generateCommentText(BasicIssue issue, Context context) {
     StringBuilder message = new StringBuilder();
     message.append("Issue linked to JIRA issue: ");
     message.append(context.projectSettings().getString(JiraConstants.SERVER_URL_PROPERTY));

--- a/src/main/java/org/sonar/plugins/jira/soap/JiraSoapServiceWrapper.java
+++ b/src/main/java/org/sonar/plugins/jira/soap/JiraSoapServiceWrapper.java
@@ -1,3 +1,23 @@
+/*
+ * Sonar, open source software quality management tool.
+ * Copyright (C) 2009 SonarSource
+ * mailto:contact AT sonarsource DOT com
+ *
+ * Sonar is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * Sonar is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with Sonar; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+
 package org.sonar.plugins.jira.soap;
 
 import java.rmi.RemoteException;

--- a/src/main/java/org/sonar/plugins/jira/soap/JiraSoapServiceWrapper.java
+++ b/src/main/java/org/sonar/plugins/jira/soap/JiraSoapServiceWrapper.java
@@ -1,0 +1,73 @@
+package org.sonar.plugins.jira.soap;
+
+import java.rmi.RemoteException;
+
+import org.apache.commons.lang.StringUtils;
+import org.sonar.api.config.Settings;
+import org.sonar.api.issue.Issue;
+import org.sonar.api.rules.RuleFinder;
+import org.sonar.api.rules.RulePriority;
+import org.sonar.plugins.jira.BasicJiraService;
+
+import com.atlassian.jira.rest.client.api.domain.BasicIssue;
+import com.atlassian.jira.rpc.soap.client.JiraSoapService;
+import com.atlassian.jira.rpc.soap.client.RemoteAuthenticationException;
+import com.atlassian.jira.rpc.soap.client.RemoteComponent;
+import com.atlassian.jira.rpc.soap.client.RemoteIssue;
+import com.atlassian.jira.rpc.soap.client.RemotePermissionException;
+import com.atlassian.jira.rpc.soap.client.RemoteValidationException;
+
+public class JiraSoapServiceWrapper extends BasicJiraService {
+
+	private JiraSoapService jiraSoapService;
+
+	public JiraSoapServiceWrapper(JiraSoapService jiraSoapService, RuleFinder ruleFinder, Settings settings) {
+		super(settings, ruleFinder);
+		this.jiraSoapService = jiraSoapService;
+	}
+
+	@Override
+	public BasicIssue createIssue(String authToken, Issue sonarIssue) {
+		try {
+			return convertIssue(jiraSoapService.createIssue(authToken, convertIssue(sonarIssue)));
+		} catch (RemoteAuthenticationException e) {
+			throw new IllegalStateException("Impossible to connect to the JIRA server because of invalid credentials.",
+					e);
+		} catch (RemotePermissionException e) {
+			throw new IllegalStateException(
+					"Impossible to create the issue on the JIRA server because user does not have enough rights.", e);
+		} catch (RemoteValidationException e) {
+			// Unfortunately the detailed cause of the error is not in fault
+			// details (ie stack) but only in fault string
+			String message = StringUtils
+					.removeStart(e.getFaultString(), "com.atlassian.jira.rpc.exception.RemoteValidationException:")
+					.trim();
+			throw new IllegalStateException("Impossible to create the issue on the JIRA server: " + message, e);
+		} catch (RemoteException e) {
+			throw new IllegalStateException("Impossible to create the issue on the JIRA server", e);
+		}
+	}
+	
+	private BasicIssue convertIssue(RemoteIssue createdIssue) {
+		return new BasicIssue(null, createdIssue.getKey(), Long.valueOf(createdIssue.getId()));
+	}
+
+	RemoteIssue convertIssue(Issue sonarIssue) {
+		RemoteIssue issue = new RemoteIssue();
+		issue.setProject(getProject());
+		issue.setType(getType());
+		issue.setPriority(sonarSeverityToJiraPriorityId(RulePriority.valueOf(sonarIssue.severity())));
+		issue.setSummary(generateIssueSummary(sonarIssue));
+		issue.setDescription(generateIssueDescription(sonarIssue));
+
+		String component = getComponentId();
+		if (component != null) {
+			RemoteComponent rc = new RemoteComponent();
+			rc.setId(component);
+			issue.setComponents(new RemoteComponent[] { rc });
+		}
+
+		return issue;
+	}
+
+}

--- a/src/test/java/org/sonar/plugins/jira/BasicJiraServiceTest.java
+++ b/src/test/java/org/sonar/plugins/jira/BasicJiraServiceTest.java
@@ -1,0 +1,51 @@
+package org.sonar.plugins.jira;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.sonar.api.CoreProperties;
+import org.sonar.api.config.PropertyDefinitions;
+import org.sonar.api.config.Settings;
+import org.sonar.api.rule.RuleKey;
+import org.sonar.api.rules.RuleFinder;
+import org.sonar.api.rules.RulePriority;
+import org.sonar.plugins.jira.reviews.JiraIssueCreator;
+import org.sonar.plugins.jira.soap.JiraSoapServiceWrapper;
+
+import com.atlassian.jira.rpc.soap.client.JiraSoapService;
+
+public class BasicJiraServiceTest {
+
+	private Settings settings;
+	private RuleFinder ruleFinder;
+
+	@Before
+	public void init() throws Exception {
+		settings = new Settings(new PropertyDefinitions(JiraIssueCreator.class, JiraPlugin.class));
+		settings.setProperty(CoreProperties.SERVER_BASE_URL, "http://my.sonar.com");
+		settings.setProperty(JiraConstants.SERVER_URL_PROPERTY, "http://my.jira.com");
+		settings.setProperty(JiraConstants.USERNAME_PROPERTY, "foo");
+		settings.setProperty(JiraConstants.PASSWORD_PROPERTY, "bar");
+		settings.setProperty(JiraConstants.JIRA_PROJECT_KEY_PROPERTY, "TEST");
+
+		ruleFinder = mock(RuleFinder.class);
+		when(ruleFinder.findByKey(RuleKey.of("squid", "CycleBetweenPackages")))
+				.thenReturn(org.sonar.api.rules.Rule.create().setName("Avoid cycle between java packages"));
+	}
+
+	@Test
+	public void shouldGiveDefaultPriority() throws Exception {
+		JiraSoapService jiraSoapService = mock(JiraSoapService.class);
+		BasicJiraService wrapper = new JiraSoapServiceWrapper(jiraSoapService, ruleFinder, settings);
+
+		assertThat(wrapper.sonarSeverityToJiraPriorityId(RulePriority.BLOCKER)).isEqualTo("1");
+		assertThat(wrapper.sonarSeverityToJiraPriorityId(RulePriority.CRITICAL)).isEqualTo("2");
+		assertThat(wrapper.sonarSeverityToJiraPriorityId(RulePriority.MAJOR)).isEqualTo("3");
+		assertThat(wrapper.sonarSeverityToJiraPriorityId(RulePriority.MINOR)).isEqualTo("4");
+		assertThat(wrapper.sonarSeverityToJiraPriorityId(RulePriority.INFO)).isEqualTo("5");
+	}
+
+}

--- a/src/test/java/org/sonar/plugins/jira/BasicJiraServiceTest.java
+++ b/src/test/java/org/sonar/plugins/jira/BasicJiraServiceTest.java
@@ -1,3 +1,23 @@
+/*
+ * Sonar, open source software quality management tool.
+ * Copyright (C) 2009 SonarSource
+ * mailto:contact AT sonarsource DOT com
+ *
+ * Sonar is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * Sonar is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with Sonar; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+
 package org.sonar.plugins.jira;
 
 import static org.fest.assertions.Assertions.assertThat;

--- a/src/test/java/org/sonar/plugins/jira/IntegrationClientTestRest.java
+++ b/src/test/java/org/sonar/plugins/jira/IntegrationClientTestRest.java
@@ -1,3 +1,23 @@
+/*
+ * Sonar, open source software quality management tool.
+ * Copyright (C) 2009 SonarSource
+ * mailto:contact AT sonarsource DOT com
+ *
+ * Sonar is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * Sonar is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with Sonar; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+
 package org.sonar.plugins.jira;
 
 import static org.mockito.Mockito.mock;

--- a/src/test/java/org/sonar/plugins/jira/IntegrationClientTestRest.java
+++ b/src/test/java/org/sonar/plugins/jira/IntegrationClientTestRest.java
@@ -1,0 +1,52 @@
+package org.sonar.plugins.jira;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.FileInputStream;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import org.sonar.api.config.PropertyDefinitions;
+import org.sonar.api.config.Settings;
+import org.sonar.api.issue.internal.DefaultIssue;
+import org.sonar.api.rule.RuleKey;
+import org.sonar.api.rules.RuleFinder;
+import org.sonar.plugins.jira.rest.JiraRestServiceWrapper;
+import org.sonar.plugins.jira.reviews.JiraIssueCreator;
+
+public class IntegrationClientTestRest {
+	
+	public static void main(String[] args) throws Exception {
+		setLoggingLevel(ch.qos.logback.classic.Level.DEBUG);
+		
+		RuleFinder ruleFinder = mock(RuleFinder.class);
+	    when(ruleFinder.findByKey(RuleKey.of("squid", "CycleBetweenPackages"))).thenReturn(org.sonar.api.rules.Rule.create().setName("Avoid cycle between java packages"));
+		JiraIssueCreator jiraIssueCreator = new JiraIssueCreator(ruleFinder);
+		
+		Properties properties = new Properties();
+		properties.load(new FileInputStream("sonar.test.properties"));
+		
+		Map<String, String> map = new HashMap<String, String>();
+		for (final String name: properties.stringPropertyNames())
+		    map.put(name, properties.getProperty(name));
+		
+		Settings settings = new Settings(new PropertyDefinitions(JiraIssueCreator.class, JiraPlugin.class));
+		settings.setProperties(map);
+		
+	    DefaultIssue sonarIssue = new DefaultIssue()
+	    	      .setKey("ABCD")
+	    	      .setMessage("The Cyclomatic Complexity of this method is 14 which is greater than 10 authorized.")
+	    	      .setSeverity("MINOR")
+	    	      .setRuleKey(RuleKey.of("squid", "CycleBetweenPackages"));
+	    
+		jiraIssueCreator.createIssue(sonarIssue, settings);
+	}
+	
+	public static void setLoggingLevel(ch.qos.logback.classic.Level level) {
+	    ch.qos.logback.classic.Logger root = (ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory.getLogger(JiraRestServiceWrapper.class);
+	    root.setLevel(level);
+	}
+	
+}

--- a/src/test/java/org/sonar/plugins/jira/reviews/JiraIssueCreatorTest.java
+++ b/src/test/java/org/sonar/plugins/jira/reviews/JiraIssueCreatorTest.java
@@ -19,15 +19,18 @@
  */
 package org.sonar.plugins.jira.reviews;
 
-import com.atlassian.jira.rpc.soap.client.JiraSoapService;
-import com.atlassian.jira.rpc.soap.client.RemoteAuthenticationException;
-import com.atlassian.jira.rpc.soap.client.RemoteComponent;
-import com.atlassian.jira.rpc.soap.client.RemoteIssue;
-import com.atlassian.jira.rpc.soap.client.RemotePermissionException;
+import static org.fest.assertions.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.mockito.Matchers;
 import org.sonar.api.CoreProperties;
 import org.sonar.api.config.PropertyDefinitions;
 import org.sonar.api.config.Settings;
@@ -35,20 +38,15 @@ import org.sonar.api.issue.Issue;
 import org.sonar.api.issue.internal.DefaultIssue;
 import org.sonar.api.rule.RuleKey;
 import org.sonar.api.rules.RuleFinder;
-import org.sonar.api.rules.RulePriority;
 import org.sonar.plugins.jira.JiraConstants;
 import org.sonar.plugins.jira.JiraPlugin;
+import org.sonar.plugins.jira.JiraSession;
+import org.sonar.plugins.jira.soap.JiraSoapServiceWrapper;
 import org.sonar.plugins.jira.soap.JiraSoapSession;
 
-import java.rmi.RemoteException;
-
-import static org.fest.assertions.Assertions.assertThat;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import com.atlassian.jira.rest.client.api.domain.BasicIssue;
+import com.atlassian.jira.rpc.soap.client.JiraSoapService;
+import com.atlassian.jira.rpc.soap.client.RemoteIssue;
 
 public class JiraIssueCreatorTest {
 
@@ -58,7 +56,7 @@ public class JiraIssueCreatorTest {
   private Issue sonarIssue;
   private Settings settings;
   private RuleFinder ruleFinder;
-
+  
   @Before
   public void init() throws Exception {
     sonarIssue = new DefaultIssue()
@@ -82,7 +80,7 @@ public class JiraIssueCreatorTest {
 
   @Test
   public void shouldCreateSoapSession() throws Exception {
-    JiraSoapSession soapSession = jiraIssueCreator.createSoapSession(settings);
+    JiraSession soapSession = jiraIssueCreator.createSoapSession(settings);
     assertThat(soapSession.getWebServiceUrl().toString()).isEqualTo("http://my.jira.com/rpc/soap/jirasoapservice-v2");
   }
 
@@ -96,193 +94,30 @@ public class JiraIssueCreatorTest {
 
     jiraIssueCreator.createSoapSession(settings);
   }
-
-  @Test
-  public void shouldFailToCreateIssueIfCantConnect() throws Exception {
-    // Given that
-    JiraSoapSession soapSession = mock(JiraSoapSession.class);
-    doThrow(RemoteException.class).when(soapSession).connect(anyString(), anyString());
-
-    // Verify
-    thrown.expect(IllegalStateException.class);
-    thrown.expectMessage("Impossible to connect to the JIRA server");
-
-    jiraIssueCreator.doCreateIssue(sonarIssue, soapSession, settings);
-  }
-
-  @Test
-  public void shouldFailToCreateIssueIfCantAuthenticate() throws Exception {
-    // Given that
-    JiraSoapService jiraSoapService = mock(JiraSoapService.class);
-    doThrow(RemoteAuthenticationException.class).when(jiraSoapService).createIssue(anyString(), any(RemoteIssue.class));
-
-    // Verify
-    thrown.expect(IllegalStateException.class);
-    thrown.expectMessage("Impossible to connect to the JIRA server (my.jira) because of invalid credentials for user foo");
-
-    jiraIssueCreator.sendRequest(jiraSoapService, "", null, "my.jira", "foo");
-  }
-
-  @Test
-  public void shouldFailToCreateIssueIfNotEnoughRights() throws Exception {
-    // Given that
-    JiraSoapService jiraSoapService = mock(JiraSoapService.class);
-    doThrow(RemotePermissionException.class).when(jiraSoapService).createIssue(anyString(), any(RemoteIssue.class));
-
-    // Verify
-    thrown.expect(IllegalStateException.class);
-    thrown.expectMessage("Impossible to create the issue on the JIRA server (my.jira) because user foo does not have enough rights.");
-
-    jiraIssueCreator.sendRequest(jiraSoapService, "", null, "my.jira", "foo");
-  }
-
-  @Test
-  public void shouldFailToCreateIssueIfRemoteError() throws Exception {
-    // Given that
-    JiraSoapService jiraSoapService = mock(JiraSoapService.class);
-    doThrow(RemoteException.class).when(jiraSoapService).createIssue(anyString(), any(RemoteIssue.class));
-
-    // Verify
-    thrown.expect(IllegalStateException.class);
-    thrown.expectMessage("Impossible to create the issue on the JIRA server (my.jira)");
-
-    jiraIssueCreator.sendRequest(jiraSoapService, "", null, "my.jira", "foo");
-  }
-
+  
   @Test
   public void shouldCreateIssue() throws Exception {
     // Given that
     RemoteIssue issue = new RemoteIssue();
+    issue.setId("1");
     JiraSoapService jiraSoapService = mock(JiraSoapService.class);
     when(jiraSoapService.createIssue(anyString(), any(RemoteIssue.class))).thenReturn(issue);
 
     JiraSoapSession soapSession = mock(JiraSoapSession.class);
     when(soapSession.getJiraSoapService()).thenReturn(jiraSoapService);
-
-    // Verify
-    RemoteIssue returnedIssue = jiraIssueCreator.doCreateIssue(sonarIssue, soapSession, settings);
-
-    verify(soapSession).connect("foo", "bar");
-    verify(soapSession).getJiraSoapService();
-    verify(soapSession).getAuthenticationToken();
-
-    assertThat(returnedIssue).isEqualTo(issue);
-  }
-
-  @Test
-  public void shouldInitRemoteIssue() throws Exception {
-    // Given that
-    RemoteIssue expectedIssue = new RemoteIssue();
-    expectedIssue.setProject("TEST");
-    expectedIssue.setType("3");
-    expectedIssue.setPriority("4");
-    expectedIssue.setSummary("SonarQube Issue #ABCD - Avoid cycle between java packages");
-    expectedIssue.setDescription("Issue detail:\n{quote}\nThe Cyclomatic Complexity of this method is 14 which is greater than 10 authorized.\n" +
-      "{quote}\n\n\nCheck it on SonarQube: http://my.sonar.com/issues/show/ABCD");
-
-    // Verify
-    RemoteIssue returnedIssue = jiraIssueCreator.initRemoteIssue(sonarIssue, settings);
-
-    assertThat(returnedIssue.getSummary()).isEqualTo(expectedIssue.getSummary());
-    assertThat(returnedIssue.getDescription()).isEqualTo(expectedIssue.getDescription());
-    assertThat(returnedIssue).isEqualTo(expectedIssue);
-  }
-  
-  @Test
-  public void shouldInitRemoteIssueWithExtendedDescription() throws Exception {
-    // Given that
-    RemoteIssue expectedIssue = new RemoteIssue();
-    expectedIssue.setProject("TEST");
-    expectedIssue.setType("3");
-    expectedIssue.setPriority("4");
-    expectedIssue.setSummary("SonarQube Issue #ABCD - Avoid cycle between java packages");
-    expectedIssue.setDescription("Issue detail:\n{quote}\nThe Cyclomatic Complexity of this method is 14 which is greater than 10 authorized.\n" +
-	  "{quote}\n\n" +
-      "component main:project:org.sonar.plugins.jira.JiraPlugin.java, line 64" +
-      "\n\nCheck it on SonarQube: http://my.sonar.com/issues/show/ABCD");
-
-    Issue filledIssue = new DefaultIssue()
-    	      .setKey("ABCD")
-    	      .setMessage("The Cyclomatic Complexity of this method is 14 which is greater than 10 authorized.")
-    	      .setSeverity("MINOR")
-    	      .setRuleKey(RuleKey.of("squid", "CycleBetweenPackages"))
-    	      .setComponentKey("main:project:org.sonar.plugins.jira.JiraPlugin.java")
-    	      .setLine(64);
+    
+    JiraSoapServiceWrapper wrapper = new JiraSoapServiceWrapper(jiraSoapService, ruleFinder, settings);    
+    when(soapSession.getJiraService(Matchers.<RuleFinder>any(), Matchers.<Settings>any())).thenReturn(wrapper);
     
     // Verify
-    RemoteIssue returnedIssue = jiraIssueCreator.initRemoteIssue(filledIssue, settings);
+    BasicIssue returnedIssue = jiraIssueCreator.doCreateIssue(sonarIssue, soapSession, settings);
+    
+    verify(soapSession).connect("foo", "bar");
+    verify(soapSession).getJiraService(Matchers.<RuleFinder>any(), Matchers.<Settings>any());
+    verify(soapSession).getAuthenticationToken();
 
-    assertThat(returnedIssue.getSummary()).isEqualTo(expectedIssue.getSummary());
-    assertThat(returnedIssue.getDescription()).isEqualTo(expectedIssue.getDescription());
-    assertThat(returnedIssue).isEqualTo(expectedIssue);
-  }  
-  
-  @Test
-  public void shouldInitRemoteIssueWithTaskType() throws Exception {
-    // Given that
-    settings.setProperty(JiraConstants.JIRA_ISSUE_TYPE_ID, "4");
-    RemoteIssue expectedIssue = new RemoteIssue();
-    expectedIssue.setProject("TEST");
-    expectedIssue.setType("4");
-    expectedIssue.setPriority("4");
-    expectedIssue.setSummary("SonarQube Issue #ABCD - Avoid cycle between java packages");
-    expectedIssue.setDescription("Issue detail:\n{quote}\nThe Cyclomatic Complexity of this method is 14 which is greater than 10 authorized.\n" +
-      "{quote}\n\n\nCheck it on SonarQube: http://my.sonar.com/issues/show/ABCD");
-
-    // Verify
-    RemoteIssue returnedIssue = jiraIssueCreator.initRemoteIssue(sonarIssue, settings);
-
-    assertThat(returnedIssue.getSummary()).isEqualTo(expectedIssue.getSummary());
-    assertThat(returnedIssue.getDescription()).isEqualTo(expectedIssue.getDescription());
-    assertThat(returnedIssue).isEqualTo(expectedIssue);
+    assertThat(String.valueOf(returnedIssue.getId())).isEqualTo(issue.getId());
+    assertThat(returnedIssue.getKey()).isEqualTo(issue.getKey());
   }
 
-  @Test
-  public void shouldInitRemoteIssueWithComponent() throws Exception {
-    // Given that
-    settings.setProperty(JiraConstants.JIRA_ISSUE_COMPONENT_ID, "123");
-    RemoteIssue expectedIssue = new RemoteIssue();
-    expectedIssue.setProject("TEST");
-    expectedIssue.setType("3");
-    expectedIssue.setPriority("4");
-    expectedIssue.setSummary("SonarQube Issue #ABCD - Avoid cycle between java packages");
-    expectedIssue.setDescription("Issue detail:\n{quote}\nThe Cyclomatic Complexity of this method is 14 which is greater than 10 authorized.\n" +
-      "{quote}\n\n\nCheck it on SonarQube: http://my.sonar.com/issues/show/ABCD");
-    expectedIssue.setComponents(new RemoteComponent[] {new RemoteComponent("123", null)});
-
-    // Verify
-    RemoteIssue returnedIssue = jiraIssueCreator.initRemoteIssue(sonarIssue, settings);
-
-    assertThat(returnedIssue).isEqualTo(expectedIssue);
-  }
-
-  @Test
-  public void shouldGiveDefaultPriority() throws Exception {
-    assertThat(jiraIssueCreator.sonarSeverityToJiraPriorityId(RulePriority.BLOCKER, settings)).isEqualTo("1");
-    assertThat(jiraIssueCreator.sonarSeverityToJiraPriorityId(RulePriority.CRITICAL, settings)).isEqualTo("2");
-    assertThat(jiraIssueCreator.sonarSeverityToJiraPriorityId(RulePriority.MAJOR, settings)).isEqualTo("3");
-    assertThat(jiraIssueCreator.sonarSeverityToJiraPriorityId(RulePriority.MINOR, settings)).isEqualTo("4");
-    assertThat(jiraIssueCreator.sonarSeverityToJiraPriorityId(RulePriority.INFO, settings)).isEqualTo("5");
-  }
-
-  @Test
-  public void shouldInitRemoteIssueWithoutName() throws Exception {
-    // Given that
-    when(ruleFinder.findByKey(RuleKey.of("squid", "CycleBetweenPackages"))).thenReturn(org.sonar.api.rules.Rule.create().setName(null));
-
-    RemoteIssue expectedIssue = new RemoteIssue();
-    expectedIssue.setProject("TEST");
-    expectedIssue.setType("3");
-    expectedIssue.setPriority("4");
-    expectedIssue.setSummary("SonarQube Issue #ABCD");
-    expectedIssue.setDescription("Issue detail:\n{quote}\nThe Cyclomatic Complexity of this method is 14 which is greater than 10 authorized.\n" +
-      "{quote}\n\n\nCheck it on SonarQube: http://my.sonar.com/issues/show/ABCD");
-
-    // Verify
-    RemoteIssue returnedIssue = jiraIssueCreator.initRemoteIssue(sonarIssue, settings);
-
-    assertThat(returnedIssue.getSummary()).isEqualTo(expectedIssue.getSummary());
-    assertThat(returnedIssue.getDescription()).isEqualTo(expectedIssue.getDescription());
-    assertThat(returnedIssue).isEqualTo(expectedIssue);
-  }
 }

--- a/src/test/java/org/sonar/plugins/jira/reviews/JiraIssueCreatorTest.java
+++ b/src/test/java/org/sonar/plugins/jira/reviews/JiraIssueCreatorTest.java
@@ -178,7 +178,7 @@ public class JiraIssueCreatorTest {
     expectedIssue.setPriority("4");
     expectedIssue.setSummary("SonarQube Issue #ABCD - Avoid cycle between java packages");
     expectedIssue.setDescription("Issue detail:\n{quote}\nThe Cyclomatic Complexity of this method is 14 which is greater than 10 authorized.\n" +
-      "{quote}\n\n\nCheck it on SonarQube: http://my.sonar.com/issue/show/ABCD");
+      "{quote}\n\n\nCheck it on SonarQube: http://my.sonar.com/issues/show/ABCD");
 
     // Verify
     RemoteIssue returnedIssue = jiraIssueCreator.initRemoteIssue(sonarIssue, settings);
@@ -187,7 +187,36 @@ public class JiraIssueCreatorTest {
     assertThat(returnedIssue.getDescription()).isEqualTo(expectedIssue.getDescription());
     assertThat(returnedIssue).isEqualTo(expectedIssue);
   }
+  
+  @Test
+  public void shouldInitRemoteIssueWithExtendedDescription() throws Exception {
+    // Given that
+    RemoteIssue expectedIssue = new RemoteIssue();
+    expectedIssue.setProject("TEST");
+    expectedIssue.setType("3");
+    expectedIssue.setPriority("4");
+    expectedIssue.setSummary("SonarQube Issue #ABCD - Avoid cycle between java packages");
+    expectedIssue.setDescription("Issue detail:\n{quote}\nThe Cyclomatic Complexity of this method is 14 which is greater than 10 authorized.\n" +
+	  "{quote}\n\n" +
+      "component main:project:org.sonar.plugins.jira.JiraPlugin.java, line 64" +
+      "\n\nCheck it on SonarQube: http://my.sonar.com/issues/show/ABCD");
 
+    Issue filledIssue = new DefaultIssue()
+    	      .setKey("ABCD")
+    	      .setMessage("The Cyclomatic Complexity of this method is 14 which is greater than 10 authorized.")
+    	      .setSeverity("MINOR")
+    	      .setRuleKey(RuleKey.of("squid", "CycleBetweenPackages"))
+    	      .setComponentKey("main:project:org.sonar.plugins.jira.JiraPlugin.java")
+    	      .setLine(64);
+    
+    // Verify
+    RemoteIssue returnedIssue = jiraIssueCreator.initRemoteIssue(filledIssue, settings);
+
+    assertThat(returnedIssue.getSummary()).isEqualTo(expectedIssue.getSummary());
+    assertThat(returnedIssue.getDescription()).isEqualTo(expectedIssue.getDescription());
+    assertThat(returnedIssue).isEqualTo(expectedIssue);
+  }  
+  
   @Test
   public void shouldInitRemoteIssueWithTaskType() throws Exception {
     // Given that
@@ -198,7 +227,7 @@ public class JiraIssueCreatorTest {
     expectedIssue.setPriority("4");
     expectedIssue.setSummary("SonarQube Issue #ABCD - Avoid cycle between java packages");
     expectedIssue.setDescription("Issue detail:\n{quote}\nThe Cyclomatic Complexity of this method is 14 which is greater than 10 authorized.\n" +
-      "{quote}\n\n\nCheck it on SonarQube: http://my.sonar.com/issue/show/ABCD");
+      "{quote}\n\n\nCheck it on SonarQube: http://my.sonar.com/issues/show/ABCD");
 
     // Verify
     RemoteIssue returnedIssue = jiraIssueCreator.initRemoteIssue(sonarIssue, settings);
@@ -218,7 +247,7 @@ public class JiraIssueCreatorTest {
     expectedIssue.setPriority("4");
     expectedIssue.setSummary("SonarQube Issue #ABCD - Avoid cycle between java packages");
     expectedIssue.setDescription("Issue detail:\n{quote}\nThe Cyclomatic Complexity of this method is 14 which is greater than 10 authorized.\n" +
-      "{quote}\n\n\nCheck it on SonarQube: http://my.sonar.com/issue/show/ABCD");
+      "{quote}\n\n\nCheck it on SonarQube: http://my.sonar.com/issues/show/ABCD");
     expectedIssue.setComponents(new RemoteComponent[] {new RemoteComponent("123", null)});
 
     // Verify
@@ -247,7 +276,7 @@ public class JiraIssueCreatorTest {
     expectedIssue.setPriority("4");
     expectedIssue.setSummary("SonarQube Issue #ABCD");
     expectedIssue.setDescription("Issue detail:\n{quote}\nThe Cyclomatic Complexity of this method is 14 which is greater than 10 authorized.\n" +
-      "{quote}\n\n\nCheck it on SonarQube: http://my.sonar.com/issue/show/ABCD");
+      "{quote}\n\n\nCheck it on SonarQube: http://my.sonar.com/issues/show/ABCD");
 
     // Verify
     RemoteIssue returnedIssue = jiraIssueCreator.initRemoteIssue(sonarIssue, settings);

--- a/src/test/java/org/sonar/plugins/jira/reviews/LinkFunctionTest.java
+++ b/src/test/java/org/sonar/plugins/jira/reviews/LinkFunctionTest.java
@@ -19,7 +19,14 @@
  */
 package org.sonar.plugins.jira.reviews;
 
-import com.atlassian.jira.rpc.soap.client.RemoteIssue;
+import static org.fest.assertions.Assertions.assertThat;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.rmi.RemoteException;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -30,11 +37,7 @@ import org.sonar.api.issue.action.Function;
 import org.sonar.api.issue.internal.DefaultIssue;
 import org.sonar.plugins.jira.JiraConstants;
 
-import java.rmi.RemoteException;
-
-import static org.fest.assertions.Assertions.assertThat;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.*;
+import com.atlassian.jira.rest.client.api.domain.BasicIssue;
 
 public class LinkFunctionTest {
 
@@ -44,7 +47,7 @@ public class LinkFunctionTest {
   private JiraIssueCreator jiraIssueCreator;
   private Issue sonarIssue;
   private Function.Context context;
-  private RemoteIssue remoteIssue;
+  private BasicIssue remoteIssue;
   private Settings settings;
 
   @Before
@@ -57,8 +60,7 @@ public class LinkFunctionTest {
     when(context.projectSettings()).thenReturn(settings);
 
     jiraIssueCreator = mock(JiraIssueCreator.class);
-    remoteIssue = new RemoteIssue();
-    remoteIssue.setKey("FOO-15");
+    remoteIssue = new BasicIssue(null, "FOO-15", 1l);
     when(jiraIssueCreator.createIssue(sonarIssue, settings)).thenReturn(remoteIssue);
 
     function = new LinkFunction(jiraIssueCreator);

--- a/src/test/java/org/sonar/plugins/jira/soap/JiraSoapServiceTest.java
+++ b/src/test/java/org/sonar/plugins/jira/soap/JiraSoapServiceTest.java
@@ -1,3 +1,23 @@
+/*
+ * Sonar, open source software quality management tool.
+ * Copyright (C) 2009 SonarSource
+ * mailto:contact AT sonarsource DOT com
+ *
+ * Sonar is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * Sonar is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with Sonar; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+
 package org.sonar.plugins.jira.soap;
 
 import static org.fest.assertions.Assertions.assertThat;

--- a/src/test/java/org/sonar/plugins/jira/soap/JiraSoapServiceTest.java
+++ b/src/test/java/org/sonar/plugins/jira/soap/JiraSoapServiceTest.java
@@ -1,0 +1,239 @@
+package org.sonar.plugins.jira.soap;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import java.rmi.RemoteException;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.sonar.api.CoreProperties;
+import org.sonar.api.config.PropertyDefinitions;
+import org.sonar.api.config.Settings;
+import org.sonar.api.issue.Issue;
+import org.sonar.api.issue.internal.DefaultIssue;
+import org.sonar.api.rule.RuleKey;
+import org.sonar.api.rules.RuleFinder;
+import org.sonar.plugins.jira.JiraConstants;
+import org.sonar.plugins.jira.JiraPlugin;
+import org.sonar.plugins.jira.reviews.JiraIssueCreator;
+
+import com.atlassian.jira.rpc.soap.client.JiraSoapService;
+import com.atlassian.jira.rpc.soap.client.RemoteAuthenticationException;
+import com.atlassian.jira.rpc.soap.client.RemoteComponent;
+import com.atlassian.jira.rpc.soap.client.RemoteIssue;
+import com.atlassian.jira.rpc.soap.client.RemotePermissionException;
+
+public class JiraSoapServiceTest {
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	private Issue sonarIssue;
+	private Settings settings;
+	private RuleFinder ruleFinder;
+
+	@Before
+	public void init() throws Exception {
+		sonarIssue = new DefaultIssue().setKey("ABCD")
+				.setMessage("The Cyclomatic Complexity of this method is 14 which is greater than 10 authorized.")
+				.setSeverity("MINOR").setRuleKey(RuleKey.of("squid", "CycleBetweenPackages"));
+
+		settings = new Settings(new PropertyDefinitions(JiraIssueCreator.class, JiraPlugin.class));
+		settings.setProperty(CoreProperties.SERVER_BASE_URL, "http://my.sonar.com");
+		settings.setProperty(JiraConstants.SERVER_URL_PROPERTY, "http://my.jira.com");
+		settings.setProperty(JiraConstants.USERNAME_PROPERTY, "foo");
+		settings.setProperty(JiraConstants.PASSWORD_PROPERTY, "bar");
+		settings.setProperty(JiraConstants.JIRA_PROJECT_KEY_PROPERTY, "TEST");
+
+		ruleFinder = mock(RuleFinder.class);
+		when(ruleFinder.findByKey(RuleKey.of("squid", "CycleBetweenPackages")))
+				.thenReturn(org.sonar.api.rules.Rule.create().setName("Avoid cycle between java packages"));
+	}
+
+	@Test
+	public void shouldFailToCreateIssueIfCantAuthenticate() throws Exception {
+		// Given that
+		JiraSoapService jiraSoapService = mock(JiraSoapService.class);
+		doThrow(RemoteAuthenticationException.class).when(jiraSoapService).createIssue(anyString(),
+				any(RemoteIssue.class));
+
+		JiraSoapServiceWrapper soapService = new JiraSoapServiceWrapper(jiraSoapService, ruleFinder, settings);
+
+		// Verify
+		thrown.expect(IllegalStateException.class);
+		thrown.expectMessage("Impossible to connect to the JIRA server because of invalid credentials.");
+		soapService.createIssue("XXX", sonarIssue);
+	}
+
+	@Test
+	public void shouldFailToCreateIssueIfNotEnoughRights() throws Exception {
+		// Given that
+		JiraSoapService jiraSoapService = mock(JiraSoapService.class);
+		doThrow(RemotePermissionException.class).when(jiraSoapService).createIssue(anyString(), any(RemoteIssue.class));
+
+		JiraSoapServiceWrapper soapService = new JiraSoapServiceWrapper(jiraSoapService, ruleFinder, settings);
+
+		// Verify
+		thrown.expect(IllegalStateException.class);
+		thrown.expectMessage(
+				"Impossible to create the issue on the JIRA server because user does not have enough rights.");
+		soapService.createIssue("XXX", sonarIssue);
+	}
+
+	@Test
+	public void shouldFailToCreateIssueIfRemoteError() throws Exception {
+		// Given that
+		JiraSoapService jiraSoapService = mock(JiraSoapService.class);
+		doThrow(RemoteException.class).when(jiraSoapService).createIssue(anyString(), any(RemoteIssue.class));
+
+		JiraSoapServiceWrapper soapService = new JiraSoapServiceWrapper(jiraSoapService, ruleFinder, settings);
+
+		// Verify
+		thrown.expect(IllegalStateException.class);
+		thrown.expectMessage("Impossible to create the issue on the JIRA server");
+		soapService.createIssue("XXX", sonarIssue);
+	}
+
+	@Test
+	public void shouldInitRemoteIssue() throws Exception {
+		// Given that
+		RemoteIssue expectedIssue = new RemoteIssue();
+		expectedIssue.setProject("TEST");
+		expectedIssue.setType("3");
+		expectedIssue.setPriority("4");
+		expectedIssue.setSummary("SonarQube Issue #ABCD - Avoid cycle between java packages");
+		expectedIssue.setDescription(
+				"Issue detail:\n{quote}\nThe Cyclomatic Complexity of this method is 14 which is greater than 10 authorized.\n"
+						+ "{quote}\n\n\nCheck it on SonarQube: http://my.sonar.com/issues/show/ABCD");
+
+		JiraSoapService jiraSoapService = mock(JiraSoapService.class);
+		JiraSoapServiceWrapper wrapper = new JiraSoapServiceWrapper(jiraSoapService, ruleFinder, settings);
+
+		// Verify
+		RemoteIssue returnedIssue = wrapper.convertIssue(sonarIssue);
+
+		assertThat(returnedIssue.getSummary()).isEqualTo(expectedIssue.getSummary());
+		assertThat(returnedIssue.getDescription()).isEqualTo(expectedIssue.getDescription());
+		assertThat(returnedIssue).isEqualTo(expectedIssue);
+	}
+
+	@Test
+	public void shouldInitRemoteIssueWithExtendedDescription() throws Exception {
+		// Given that
+		RemoteIssue expectedIssue = new RemoteIssue();
+		expectedIssue.setProject("TEST");
+		expectedIssue.setType("3");
+		expectedIssue.setPriority("4");
+		expectedIssue.setSummary("SonarQube Issue #ABCD - Avoid cycle between java packages");
+		expectedIssue.setDescription(
+				"Issue detail:\n{quote}\nThe Cyclomatic Complexity of this method is 14 which is greater than 10 authorized.\n"
+						+ "{quote}\n\n" + "component main:project:org.sonar.plugins.jira.JiraPlugin.java, line 64"
+						+ "\n\nCheck it on SonarQube: http://my.sonar.com/issues/show/ABCD");
+
+		Issue filledIssue = new DefaultIssue().setKey("ABCD")
+				.setMessage("The Cyclomatic Complexity of this method is 14 which is greater than 10 authorized.")
+				.setSeverity("MINOR").setRuleKey(RuleKey.of("squid", "CycleBetweenPackages"))
+				.setComponentKey("main:project:org.sonar.plugins.jira.JiraPlugin.java").setLine(64);
+
+		JiraSoapService jiraSoapService = mock(JiraSoapService.class);
+		JiraSoapServiceWrapper wrapper = new JiraSoapServiceWrapper(jiraSoapService, ruleFinder, settings);
+		// Verify
+		RemoteIssue returnedIssue = wrapper.convertIssue(filledIssue);
+
+		assertThat(returnedIssue.getSummary()).isEqualTo(expectedIssue.getSummary());
+		assertThat(returnedIssue.getDescription()).isEqualTo(expectedIssue.getDescription());
+		assertThat(returnedIssue).isEqualTo(expectedIssue);
+	}
+	
+	  @Test
+	  public void shouldInitRemoteIssueWithTaskType() throws Exception {
+	    // Given that
+	    settings.setProperty(JiraConstants.JIRA_ISSUE_TYPE_ID, "4");
+	    RemoteIssue expectedIssue = new RemoteIssue();
+	    expectedIssue.setProject("TEST");
+	    expectedIssue.setType("4");
+	    expectedIssue.setPriority("4");
+	    expectedIssue.setSummary("SonarQube Issue #ABCD - Avoid cycle between java packages");
+	    expectedIssue.setDescription("Issue detail:\n{quote}\nThe Cyclomatic Complexity of this method is 14 which is greater than 10 authorized.\n" +
+	      "{quote}\n\n\nCheck it on SonarQube: http://my.sonar.com/issues/show/ABCD");
+
+	    JiraSoapService jiraSoapService = mock(JiraSoapService.class);
+		JiraSoapServiceWrapper wrapper = new JiraSoapServiceWrapper(jiraSoapService, ruleFinder, settings);
+	    // Verify
+	    RemoteIssue returnedIssue = wrapper.convertIssue(sonarIssue);
+
+	    assertThat(returnedIssue.getSummary()).isEqualTo(expectedIssue.getSummary());
+	    assertThat(returnedIssue.getDescription()).isEqualTo(expectedIssue.getDescription());
+	    assertThat(returnedIssue).isEqualTo(expectedIssue);
+	  }
+
+	  @Test
+	  public void shouldInitRemoteIssueWithComponent() throws Exception {
+	    // Given that
+	    settings.setProperty(JiraConstants.JIRA_ISSUE_COMPONENT_ID, "123");
+	    RemoteIssue expectedIssue = new RemoteIssue();
+	    expectedIssue.setProject("TEST");
+	    expectedIssue.setType("3");
+	    expectedIssue.setPriority("4");
+	    expectedIssue.setSummary("SonarQube Issue #ABCD - Avoid cycle between java packages");
+	    expectedIssue.setDescription("Issue detail:\n{quote}\nThe Cyclomatic Complexity of this method is 14 which is greater than 10 authorized.\n" +
+	      "{quote}\n\n\nCheck it on SonarQube: http://my.sonar.com/issues/show/ABCD");
+	    expectedIssue.setComponents(new RemoteComponent[] {new RemoteComponent("123", null)});
+
+	    JiraSoapService jiraSoapService = mock(JiraSoapService.class);
+		JiraSoapServiceWrapper wrapper = new JiraSoapServiceWrapper(jiraSoapService, ruleFinder, settings);
+	    // Verify
+	    RemoteIssue returnedIssue = wrapper.convertIssue(sonarIssue);
+
+	    assertThat(returnedIssue).isEqualTo(expectedIssue);
+	  }
+
+	  @Test
+	  public void shouldInitRemoteIssueWithoutName() throws Exception {
+	    // Given that
+	    when(ruleFinder.findByKey(RuleKey.of("squid", "CycleBetweenPackages"))).thenReturn(org.sonar.api.rules.Rule.create().setName(null));
+
+	    RemoteIssue expectedIssue = new RemoteIssue();
+	    expectedIssue.setProject("TEST");
+	    expectedIssue.setType("3");
+	    expectedIssue.setPriority("4");
+	    expectedIssue.setSummary("SonarQube Issue #ABCD");
+	    expectedIssue.setDescription("Issue detail:\n{quote}\nThe Cyclomatic Complexity of this method is 14 which is greater than 10 authorized.\n" +
+	      "{quote}\n\n\nCheck it on SonarQube: http://my.sonar.com/issues/show/ABCD");
+
+	    JiraSoapService jiraSoapService = mock(JiraSoapService.class);
+		JiraSoapServiceWrapper wrapper = new JiraSoapServiceWrapper(jiraSoapService, ruleFinder, settings);
+	    // Verify
+	    RemoteIssue returnedIssue = wrapper.convertIssue(sonarIssue);
+
+	    assertThat(returnedIssue.getSummary()).isEqualTo(expectedIssue.getSummary());
+	    assertThat(returnedIssue.getDescription()).isEqualTo(expectedIssue.getDescription());
+	    assertThat(returnedIssue).isEqualTo(expectedIssue);
+	  }
+
+	  @Test
+	  public void shouldFailToCreateIssueIfCantConnect() throws Exception {
+		// Given that
+		JiraSoapService soapService = mock(JiraSoapService.class);
+		doThrow(RemoteException.class).when(soapService).login(anyString(), anyString());
+	    
+		JiraSoapSession soapSession = spy(new JiraSoapSession());
+		doReturn(soapService).when(soapSession).getJiraSoapService();
+		
+	    // Verify
+	    thrown.expect(IllegalStateException.class);
+	    thrown.expectMessage("Impossible to connect to the JIRA server");
+
+	    soapSession.connect("aa", "vv");
+	  }
+	  
+}


### PR DESCRIPTION
+ I refactor code, so used jira api is plugable (you can choose new REST api in global configuration, SOAP is default one) (sonar.jira.rest property).
+ I improved the jira ticket description so it contains line number and class where problem occured.
+ New option to add label to created jira ticket (label name configured using sonar.jira.issue.sonar.label property).