### PR TITLE
Fix link in issue description

### DIFF
--- a/src/main/java/org/sonar/plugins/jira/reviews/JiraIssueCreator.java
+++ b/src/main/java/org/sonar/plugins/jira/reviews/JiraIssueCreator.java
@@ -238,7 +238,7 @@ public class JiraIssueCreator implements ServerExtension {
     description.append(QUOTE);
     description.append("\n\nCheck it on SonarQube: ");
     description.append(settings.getString(CoreProperties.SERVER_BASE_URL));
-    description.append("/issue/show/");
+    description.append("/issues/show/");
     description.append(sonarIssue.key());
     return description.toString();
   }

--- a/src/test/java/org/sonar/plugins/jira/reviews/JiraIssueCreatorTest.java
+++ b/src/test/java/org/sonar/plugins/jira/reviews/JiraIssueCreatorTest.java
@@ -178,7 +178,7 @@ public class JiraIssueCreatorTest {
     expectedIssue.setPriority("4");
     expectedIssue.setSummary("SonarQube Issue #ABCD - Avoid cycle between java packages");
     expectedIssue.setDescription("Issue detail:\n{quote}\nThe Cyclomatic Complexity of this method is 14 which is greater than 10 authorized.\n" +
-      "{quote}\n\n\nCheck it on SonarQube: http://my.sonar.com/issue/show/ABCD");
+      "{quote}\n\n\nCheck it on SonarQube: http://my.sonar.com/issues/show/ABCD");
 
     // Verify
     RemoteIssue returnedIssue = jiraIssueCreator.initRemoteIssue(sonarIssue, settings);
@@ -198,7 +198,7 @@ public class JiraIssueCreatorTest {
     expectedIssue.setPriority("4");
     expectedIssue.setSummary("SonarQube Issue #ABCD - Avoid cycle between java packages");
     expectedIssue.setDescription("Issue detail:\n{quote}\nThe Cyclomatic Complexity of this method is 14 which is greater than 10 authorized.\n" +
-      "{quote}\n\n\nCheck it on SonarQube: http://my.sonar.com/issue/show/ABCD");
+      "{quote}\n\n\nCheck it on SonarQube: http://my.sonar.com/issues/show/ABCD");
 
     // Verify
     RemoteIssue returnedIssue = jiraIssueCreator.initRemoteIssue(sonarIssue, settings);
@@ -218,7 +218,7 @@ public class JiraIssueCreatorTest {
     expectedIssue.setPriority("4");
     expectedIssue.setSummary("SonarQube Issue #ABCD - Avoid cycle between java packages");
     expectedIssue.setDescription("Issue detail:\n{quote}\nThe Cyclomatic Complexity of this method is 14 which is greater than 10 authorized.\n" +
-      "{quote}\n\n\nCheck it on SonarQube: http://my.sonar.com/issue/show/ABCD");
+      "{quote}\n\n\nCheck it on SonarQube: http://my.sonar.com/issues/show/ABCD");
     expectedIssue.setComponents(new RemoteComponent[] {new RemoteComponent("123", null)});
 
     // Verify
@@ -247,7 +247,7 @@ public class JiraIssueCreatorTest {
     expectedIssue.setPriority("4");
     expectedIssue.setSummary("SonarQube Issue #ABCD");
     expectedIssue.setDescription("Issue detail:\n{quote}\nThe Cyclomatic Complexity of this method is 14 which is greater than 10 authorized.\n" +
-      "{quote}\n\n\nCheck it on SonarQube: http://my.sonar.com/issue/show/ABCD");
+      "{quote}\n\n\nCheck it on SonarQube: http://my.sonar.com/issues/show/ABCD");
 
     // Verify
     RemoteIssue returnedIssue = jiraIssueCreator.initRemoteIssue(sonarIssue, settings);


### PR DESCRIPTION
We can´t follow back the sonar issue using link description created on JIRA

The URL is missing letter s.   

Unless /issue/show  use /issues/show 

Tested with Sonar 5.2