### PR TITLE
Update permalinks to issues for SonarQube 5.1+

### DIFF
--- a/src/main/java/org/sonar/plugins/jira/reviews/JiraIssueCreator.java
+++ b/src/main/java/org/sonar/plugins/jira/reviews/JiraIssueCreator.java
@@ -238,7 +238,7 @@ public class JiraIssueCreator implements ServerExtension {
     description.append(QUOTE);
     description.append("\n\nCheck it on SonarQube: ");
     description.append(settings.getString(CoreProperties.SERVER_BASE_URL));
-    description.append("/issue/show/");
+    description.append("/issues/search#issues=");
     description.append(sonarIssue.key());
     return description.toString();
   }

--- a/src/test/java/org/sonar/plugins/jira/reviews/JiraIssueCreatorTest.java
+++ b/src/test/java/org/sonar/plugins/jira/reviews/JiraIssueCreatorTest.java
@@ -178,7 +178,7 @@ public class JiraIssueCreatorTest {
     expectedIssue.setPriority("4");
     expectedIssue.setSummary("SonarQube Issue #ABCD - Avoid cycle between java packages");
     expectedIssue.setDescription("Issue detail:\n{quote}\nThe Cyclomatic Complexity of this method is 14 which is greater than 10 authorized.\n" +
-      "{quote}\n\n\nCheck it on SonarQube: http://my.sonar.com/issue/show/ABCD");
+      "{quote}\n\n\nCheck it on SonarQube: http://my.sonar.com/issues/search#issues=ABCD");
 
     // Verify
     RemoteIssue returnedIssue = jiraIssueCreator.initRemoteIssue(sonarIssue, settings);
@@ -198,7 +198,7 @@ public class JiraIssueCreatorTest {
     expectedIssue.setPriority("4");
     expectedIssue.setSummary("SonarQube Issue #ABCD - Avoid cycle between java packages");
     expectedIssue.setDescription("Issue detail:\n{quote}\nThe Cyclomatic Complexity of this method is 14 which is greater than 10 authorized.\n" +
-      "{quote}\n\n\nCheck it on SonarQube: http://my.sonar.com/issue/show/ABCD");
+      "{quote}\n\n\nCheck it on SonarQube: http://my.sonar.com/issues/search#issues=ABCD");
 
     // Verify
     RemoteIssue returnedIssue = jiraIssueCreator.initRemoteIssue(sonarIssue, settings);
@@ -218,7 +218,7 @@ public class JiraIssueCreatorTest {
     expectedIssue.setPriority("4");
     expectedIssue.setSummary("SonarQube Issue #ABCD - Avoid cycle between java packages");
     expectedIssue.setDescription("Issue detail:\n{quote}\nThe Cyclomatic Complexity of this method is 14 which is greater than 10 authorized.\n" +
-      "{quote}\n\n\nCheck it on SonarQube: http://my.sonar.com/issue/show/ABCD");
+      "{quote}\n\n\nCheck it on SonarQube: http://my.sonar.com/issues/search#issues=ABCD");
     expectedIssue.setComponents(new RemoteComponent[] {new RemoteComponent("123", null)});
 
     // Verify
@@ -247,7 +247,7 @@ public class JiraIssueCreatorTest {
     expectedIssue.setPriority("4");
     expectedIssue.setSummary("SonarQube Issue #ABCD");
     expectedIssue.setDescription("Issue detail:\n{quote}\nThe Cyclomatic Complexity of this method is 14 which is greater than 10 authorized.\n" +
-      "{quote}\n\n\nCheck it on SonarQube: http://my.sonar.com/issue/show/ABCD");
+      "{quote}\n\n\nCheck it on SonarQube: http://my.sonar.com/issues/search#issues=ABCD");
 
     // Verify
     RemoteIssue returnedIssue = jiraIssueCreator.initRemoteIssue(sonarIssue, settings);


### PR DESCRIPTION
I did not see a way to dynamically generate the URL.  It appears to be hardcoded other places (https://github.com/SonarSource/sonarqube/blob/f5d3461ffd3c5936a3bdc0999f6a9f71b9f10cd2/server/sonar-server/src/main/java/org/sonar/server/issue/notification/IssueChangesEmailTemplate.java#L104).

Perhaps this class (https://github.com/SonarSource/sonar-update-center/blob/1.14/sonar-update-center-common/src/main/java/org/sonar/updatecenter/common/Version.java) could be used in conjunction with settings.getString(CoreProperties.SERVER_VERSION) but I'm not so sure that adding the update center as a dependency or duplicating that class is the right approach.